### PR TITLE
Accessibility: add aria-label to close button

### DIFF
--- a/FigcaptionRole.js
+++ b/FigcaptionRole.js
@@ -1,0 +1,17 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var FigcaptionRole = {
+  relatedConcepts: [{
+    module: 'HTML',
+    concept: {
+      name: 'figcaption'
+    }
+  }],
+  type: 'structure'
+};
+var _default = FigcaptionRole;
+exports["default"] = _default;


### PR DESCRIPTION
Adds an aria-label to the modal close button to improve screen-reader clarity and meet WCAG guidelines. Updated CloseButton component to accept and forward an aria-label prop and adjusted tests/snapshots accordingly.